### PR TITLE
[WIP] Import pluggy directly

### DIFF
--- a/pytest_metadata/plugin.py
+++ b/pytest_metadata/plugin.py
@@ -5,7 +5,7 @@
 import os
 import platform
 
-import _pytest._pluggy as pluggy
+import pluggy
 import pytest
 import py
 


### PR DESCRIPTION
Sorry, @davehunt - I haven't run this at all, and don't know the ramifications of this change, other than pytest has stopped vendoring pluggy as of 3.3.0 (see https://github.com/pytest-dev/pytest/pull/2719).  (Perhaps I should've just filed an Issue, instead.)